### PR TITLE
update base image and incorporate mkdocs-yamp

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -14,7 +14,7 @@ clean:
 ############################
 
 # builds the jte docs builder image
-docsImage := "jte-docs-builder"
+docsImage := "docs-builder"
 buildDocsImage:
   docker build docs -t {{docsImage}}
 
@@ -24,7 +24,7 @@ docs: buildDocsImage
 
 # serve the docs locally for development
 serve: buildDocsImage
-  docker run --rm -p 8000:8000 -v $(pwd):/docs {{docsImage}} serve -a 0.0.0.0:8000
+  docker run --rm -p 8000:8000 -v ~/.git-credentials:/root/.git-credentials -v $(pwd):/docs -w /docs {{docsImage}} serve -a 0.0.0.0:8000
 
 lint-docs: lint-prose lint-markdown
 
@@ -35,13 +35,6 @@ lint-prose:
 # use markdownlit to lint the docs
 lint-markdown: 
   docker run -v $(pwd):/app -w /app davidanson/markdownlint-cli2:0.3.1 "docs/**/*.md"
-
-# update current docs
-update-docs: buildDocsImage
-    #!/usr/bin/env bash
-    version=$(./gradlew -q printJTEVersion)
-    docker run --rm -v ~/.git-credentials:/root/.git-credentials -v $(pwd):/app -w /app --entrypoint=mike jte-docs-builder deploy -f --push $version
-    echo "INFO     -  Published version '$version' to GitHub Pages"
 
 ###################
 # Aggregate Tasks

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,9 +1,13 @@
-FROM squidfunk/mkdocs-material:8.0.2
-RUN pip install \
-    mkdocs-gen-files \
-    mkdocs-exclude \
-    mike \
-    pymdown-extensions && \
-    git config --global user.name "docs deployer" && \
+FROM python:3
+
+# git auth is provided by mounting a git credentials file
+# to /root/.git-credentials
+RUN git config --global user.name "docs deployer" && \
     git config --global user.email "null@null.com" && \
     git config --global credential.helper 'store --file=/root/.git-credentials'
+
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+ENTRYPOINT ["mkdocs"]
+CMD ["serve"]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+mkdocs==1.4.0
+mkdocs-material==8.5.3
+mkdocs-gen-files==0.4.0
+mkdocs-exclude==1.0.2
+mike==1.1.2
+pymdown-extensions==9.5
+mkdocs-yamp==0.1.1


### PR DESCRIPTION
Switch to using the python:3 base image so that we can include the latest mkdocs version.
also installs [mkdocs-yamp](https://github.com/boozallen/mkdocs-yamp-plugin) so that we can aggregate content from multiple directories